### PR TITLE
fix: 빌드 시 필요한 jar 설정 및 cloud dependency 수정 #5

### DIFF
--- a/admin-api/build.gradle
+++ b/admin-api/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2022.0.2"
+    }
+}
+
+bootJar {
+    enabled = true
+}
+
 jar {
     enabled = false
 }

--- a/admin-core/build.gradle
+++ b/admin-core/build.gradle
@@ -2,3 +2,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
+
+jar {
+    enabled = true
+}
+
+bootJar {
+    enabled = false
+}


### PR DESCRIPTION
## ❗️관련 이슈번호
- Close #5 

## ⚙️ 어떤 기능을 개발했나요?
- Spring cloud를 위한 의존성을 추가했어요.
- 필요한 jar만 빌드하도록 수정했어요.